### PR TITLE
feat: Enables support for the initial_group_config parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.14
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Functional examples are included in the [examples](./examples/) directory.
 | display\_name | Display name of the group | `string` | `""` | no |
 | domain | Domain of the organization to create the group in. One of domain or customer\_id must be specified | `string` | `""` | no |
 | id | ID of the group. For Google-managed entities, the ID must be the email address the group | `any` | n/a | yes |
+| initial\_group\_config | The initial configuration options for creating a Group. See the API reference for possible values. Possible values are INITIAL\_GROUP\_CONFIG\_UNSPECIFIED, WITH\_INITIAL\_OWNER, and EMPTY. | `string` | `"EMPTY"` | no |
 | managers | Managers of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account | `list` | `[]` | no |
 | members | Members of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account | `list` | `[]` | no |
 | owners | Owners of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account | `list` | `[]` | no |
@@ -84,11 +85,6 @@ limitations:
     ]
     ```
 
-* [InitialGroupConfig](https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups/create#initialgroupconfig)
-    is not supported in the `google_cloud_identity_group` resource, which
-    prevents non-admins from creating groups in an organization, even when the
-    organization is configured to allow anyone to create groups.
-
 * Only
     [Google Groups](https://cloud.google.com/identity/docs/groups#group_properties)
     are supported.
@@ -103,7 +99,7 @@ These sections describe requirements for using this module.
 
 The following dependencies must be available:
 
-* [Terraform][terraform] v0.12
+* [Terraform][terraform] v0.13
 * [Terraform Provider for GCP][terraform-provider-gcp] plugin v2.0
 
 ### Permissions

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.14'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,6 +29,7 @@ suites:
   - name: simple_example
     driver:
       root_module_directory: test/fixtures/simple_example/
+      verify_version: false
     verifier:
       color: false
       systems:

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,8 @@ resource "google_cloud_identity_group" "group" {
 
   parent = "customers/${local.customer_id}"
 
+  initial_group_config = var.initial_group_config
+
   group_key {
     id = var.id
   }

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,8 @@ variable "members" {
   description = "Members of the group. Each entry is the ID of an entity. For Google-managed entities, the ID must be the email address of an existing group, user or service account"
   default     = []
 }
+
+variable "initial_group_config" {
+  description = "The initial configuration options for creating a Group. See the API reference for possible values. Possible values are INITIAL_GROUP_CONFIG_UNSPECIFIED, WITH_INITIAL_OWNER, and EMPTY."
+  default     = "EMPTY"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.67.0"
+      version = "~> 3.67"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -20,11 +20,11 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.53"
+      version = "~> 3.67"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.53"
+      version = "~> 3.67.0"
     }
   }
 


### PR DESCRIPTION
Enables specifying the initial_group_config parameter so that groups can be created without administrative rights. Closes #21 