### PR TITLE
Support for changing group labels 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ locals {
     "security" = "cloudidentity.googleapis.com/groups.security"
     "external" = "system/groups/external"
   }
+  required_labels = {
+    for label_name in var.label_keys : local.label_keys[label_name] => ""
+  }
 }
 
 resource "google_cloud_identity_group" "group" {
@@ -45,9 +48,7 @@ resource "google_cloud_identity_group" "group" {
     id = var.id
   }
 
-  labels = {
-    local.label_keys[local.type] = ""
-  }
+  labels = local.required_labels
 }
 
 resource "google_cloud_identity_group_membership" "owners" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,9 @@ variable "initial_group_config" {
   default     = "EMPTY"
 }
    
-variable "lifecycle_ignore_changes" {
-  description = "Enables a possibility to ignore changes. Useful for existing labels" 
-  default = []
+variable "label_keys" {
+  description = "Labels to apply to the group. Currently only 'default' is supported"
+  default = [
+    "default"
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,8 @@ variable "initial_group_config" {
   description = "The initial configuration options for creating a Group. See the API reference for possible values. Possible values are INITIAL_GROUP_CONFIG_UNSPECIFIED, WITH_INITIAL_OWNER, and EMPTY."
   default     = "EMPTY"
 }
+   
+variable "lifecycle_ignore_changes" {
+  description = "Enables a possibility to ignore changes. Useful for existing labels" 
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,7 +63,7 @@ variable "initial_group_config" {
   description = "The initial configuration options for creating a Group. See the API reference for possible values. Possible values are INITIAL_GROUP_CONFIG_UNSPECIFIED, WITH_INITIAL_OWNER, and EMPTY."
   default     = "EMPTY"
 }
-   
+
 variable "label_keys" {
   description = "Labels to apply to the group. Currently only 'default' is supported"
   default = [


### PR DESCRIPTION
When creating a new group or maintaining an existing one, there's a need to decide which type of group we would like to support. GCP allows the usage of two: `DISCUSSION` and `SECURITY`. Currently, it's not possible to decide which labels to use and GCP doesn't allow removing existing labels, therefore once a group is marked with either of the above, there's no way to apply terraform anymore. 

This PR helps overcome the issue of existing labels and also exposes a new feature - support to add a security group. 

Usage example: 

```
module "group" {
  for_each     = { for group in local.group_members : group.group_name => group }
  source       = "terraform-google-modules/group/google"
  version      = "~> 0.1"
  customer_id  = local.customer_id
  id           = "${each.value.group_name}@${local.google_domain}"
  display_name = each.value.display_name
  description  = each.value.description
  members      = each.value.members
  label_keys = [
    "default",
    "security",
  ]
}
``` 