### PR TITLE
add lifecycle.ignore_changes for initial_group_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,10 @@ resource "google_cloud_identity_group" "group" {
   }
 
   labels = { for t in var.types : local.label_keys[t] => "" }
+  
+  lifecycle {
+    ignore_changes = [initial_group_config]
+  }
 }
 
 resource "google_cloud_identity_group_membership" "owners" {


### PR DESCRIPTION
resolves #67

`google_cloud_identity_group` has optional argument `initial_group_config` ([ref](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_identity_group#initial_group_config-1)), whose default is `EMPTY`.

If we dont set this attribute in the `terraform-google-modules/group/google` module, the default `EMPTY` value is used internally.
As the result, an imported group (with `initlal_group_config=null`) will be replace when running `terraform apply`.

Therefore, I added `lifecycle.ignore_changes` for this attribute.
