### PR TITLE
feat: add validation for customer_id (#16)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "customer_id" {
   type        = string
   description = "Customer ID of the organization to create the group in. One of domain or customer_id must be specified"
   default     = ""
+
+  validation {
+    condition     = var.customer_id == "" || can(regex("^C0[a-z0-9]{7}$", var.customer_id))
+    error_message = "customer_id must be in the form C0xxxxxxx (without the 'customers/' prefix)."
+  }
 }
 
 variable "owners" {


### PR DESCRIPTION
Fixes #16.

## Summary
Add Terraform variable validation for `customer_id` to enforce the expected format (C0xxxxxxx).

This module constructs the full parent as `customers/${customer_id}`, so the input should not include the `customers/` prefix.

## Testing
- N/A (static validation only)

